### PR TITLE
FIX: special remote publication

### DIFF
--- a/neurodatapub/utils/datalad.py
+++ b/neurodatapub/utils/datalad.py
@@ -141,7 +141,6 @@ def publish_dataset(
     """
     res = datalad.api.push(
         dataset=datalad_dataset_dir,
-        to='github',
-        jobs='auto'
+        to='github'
     )
     return res

--- a/neurodatapub/utils/datalad.py
+++ b/neurodatapub/utils/datalad.py
@@ -139,7 +139,7 @@ def publish_dataset(
     `res` : string
         Output of `datalad.api.publish()
     """
-    res = datalad.api.publish(
+    res = datalad.api.push(
         dataset=datalad_dataset_dir,
         to='github',
         jobs='auto'


### PR DESCRIPTION
**Problem**
Datalad was not managing well the special remote during publication with `datalad.api.publish`, such that we could not get any file of the dataset from the `ssh_remote` special sibling

**Solution**
Change `datalad.api.publish` to `datalad.api.push`