### PR TITLE
REL: Version v0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # Ignore build directory
 _build
 build
+
+# Ignore pycache
+__pycache__

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ of Competence in Research (NCCR) "SYNAPSY – Synaptic Bases of Mental
 Diseases" NCCR-SYNAPSY](https://nccr-synapsy.ch/), as well as for
 open-source software distribution.
 
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/NCCR-SYNAPSY/neurodatapub?include_prereleases)
+[![PyPI](https://img.shields.io/pypi/v/neurodatapub)](https://pypi.org/project/neurodatapub/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5163950.svg)](https://doi.org/10.5281/zenodo.5163950)
 [![Documentation Status](https://readthedocs.org/projects/neurodatapub/badge/?version=latest)](https://neurodatapub.readthedocs.io/en/latest/?badge=latest)
 [![CircleCI](https://circleci.com/gh/NCCR-SYNAPSY/neurodatapub/tree/main.svg?style=shield)](https://circleci.com/gh/NCCR-SYNAPSY/neurodatapub/tree/main)

--- a/conda/environment_macosx.yml
+++ b/conda/environment_macosx.yml
@@ -12,7 +12,6 @@ dependencies:
 - traitsui=7.2.1
 - datalad=0.14.5
 - rsync=3.2.3
-- git-annex=8.20210621
 
 - pip:
     - argparse==1.4.0

--- a/docs/bids.rst
+++ b/docs/bids.rst
@@ -2,7 +2,7 @@
 .. _bids:
 
 *******************************************
-BIDS standard
+BIDS Standard
 *******************************************
 
 A dataset published with `NeuroDataPub` HAS TO ADOPT the :abbr:`BIDS (Brain Imaging Data Structure)` standard for data organization and is developed following the BIDS App standard. This means that `NeuroDataPub` handles only datasets formatted following the BIDS standard (See :ref:`cmdusage` for more details).

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -4,6 +4,15 @@
 NeuroDataPub Assistant Guide
 *********************************
 
+.. important::
+    `NeuroDataPub` takes as principal input the path of your dataset. The input dataset is required to be in *valid BIDS format*. See :ref:`BIDS standard <bids>` for more information about BIDS.
+
+    Before using `NeuroDataPub`, your dataset should be validated with the free, online `BIDS Validator <http://bids-standard.github.io/bids-validator/>`_,
+    or its standalone version.
+
+    Note also that before using `NeuroDataPub`, your remote data server should provide at least an installation of `git-annex`. Please see :ref:`remote_setup` for instructions.
+
+
 Introduction
 ============
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,7 @@ Contents
    :caption: Getting started
 
    installation
+   remote_setup
 
 .. _user-docs:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,9 @@ This tool is developed by the `Connectomics Lab <https://wp.unil.ch/connectomics
 within the lab and within the `National Centre of Competence in Research (NCCR) "SYNAPSY – Synaptic Bases of Mental Diseases" NCCR-SYNAPSY <https://nccr-synapsy.ch/>`_,
 as well as for open-source software distribution.
 
+.. image:: https://img.shields.io/pypi/v/neurodatapub
+  :target: https://pypi.org/project/neurodatapub/
+  :alt: PyPI
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5163950.svg
   :target: https://doi.org/10.5281/zenodo.5163950
   :alt: Digital Object Identifier

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,13 +34,23 @@ Installation of Miniconda 3
 Creation of `neurodatapub-env` conda environment
 -------------------------------------------------
 
-* Download the conda `environment.yml <https://github.com/NCCR-SYNAPSY/neurodatapub/raw/main/conda/environment.yml>`_
+* Download the appropriate conda `environment.yml <https://github.com/NCCR-SYNAPSY/neurodatapub/raw/main/conda/environment.yml>`_ or
+  `environment_macosx.yml <https://github.com/NCCR-SYNAPSY/neurodatapub/raw/main/conda/environment_macosx.yml>`_
+  depending on your OS.
+
+  .. important::
+     It seems there is no conda package for `git-annex` available on Mac.
+     For convenience, we created an additional `environment_macosx.yml <https://github.com/NCCR-SYNAPSY/neurodatapub/raw/main/conda/environment_macosx.yml>`_
+     miniconda3 environment where the line `- git-annex=[...]` has been removed.
+     Git-annex should be installed on MacOSX using `brew <https://brew.sh/index_fr>`_
+     i.e. ``brew install git-annex``.
+     See https://git-annex.branchable.com/install/ for more details.
 
 * Create the `neurodatapub-env` conda environment:
 
   .. parsed-literal::
 
-     $ conda env create -f /path/to/downloaded/environment.yml
+     $ conda env create -f /path/to/downloaded/environment[_macosx].yml
 
   This will create a Python 3.8 environment with all dependencies installed.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,9 +22,14 @@ However, if you are not afraid by the creation of JSON files, or you feel more c
 Installation of Miniconda 3
 ------------------------------
 
-* Download the installer of `Miniconda 3` corresponding to your 32/64bits MacOSX/Linux/Win system from https://conda.io/miniconda.html.
+* Download the installer of `Miniconda 3` corresponding to your 32/64bits MacOSX/Linux/Win system from https://conda.io/miniconda.html. This can alternatively be done in the terminal::
 
-* Execute the downloaded script to install it.
+    $ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-<YOUR-OS>-x86_64.sh
+
+* Execute the downloaded script to install it::
+
+    $ bash Miniconda3-latest-<YOUR-OS>-x86_64.sh
+
 
 .. note:: `NeuroDataPub` has been tested only on Ubuntu and MacOSX.
 
@@ -64,7 +69,7 @@ Once the `neurodatapub-env` conda environment, `NeuroDataPub` can be installed i
 
      $ pip install "git+https://github.com/NCCR-SYNAPSY/neurodatapub.git"
 
-* You are ready to use `NeuroDataPub`!
+* You are almost ready to use `NeuroDataPub`! You would need to have at least `git-annex` installed on the remote data server. Please see :ref:`remote_setup` for instructions.
 
 Help/Questions
 --------------

--- a/docs/remote_setup.rst
+++ b/docs/remote_setup.rst
@@ -1,0 +1,87 @@
+.. _remote_setup:
+
+*********************************
+Remote Data Server Setup
+*********************************
+
+In this section, you will see how to setup your special remote data server to store Datalad-managed datasets.
+As one normal user usually does not have root/admin privileges to the server, this prevents her/him to install them via `apt-get`.
+
+In this case, there exist two user-based installation solutions, depending on the accessibility of your remote data server to internet:
+
+1. Internet access: :ref:`remote_setup_conda`
+2. No internet access: :ref:`remote_setup_gitannex`
+
+
+.. _remote_setup_conda:
+
+Installation with Conda
+=========================
+
+From `solutions <http://handbook.datalad.org/en/latest/intro/installation.html#linux-machines-with-no-root-access-e-g-hpc-systems>`_ of the DataLad handbook, installation with `Conda` is the most convenient user-based installation but it requires an internet access from the remote data server.
+
+In this situation, with `Conda` or `Miniconda` installed (If not, please check :ref:`manual-install-miniconda3` for instructions), the DataLad package can be installed from the `conda-forge` channel as follows::
+
+    $ conda install -c conda-forge datalad
+
+In general, all software dependencies of DataLad (including git-annex) are automatically installed too.
+
+.. note::
+    This approach has the advantage that any dataset could be then directly managed on the remote server with Datalad.
+
+
+.. _remote_setup_gitannex:
+
+Installation of standalone `git-annex`
+========================================
+The remote data server might not be connected to internet for security reasons and so, it would be impossible to install DataLad via `conda` or `pip`. But do not worry! One can still use a Linux standalone distribution of `git-annex`. It consists of the following steps:
+
+1. Download from the official website the Linux standalone for git-annex: `git-annex-standalone-amd64.tar.gz <https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-amd64.tar.gz>`_.
+
+2. Create a folder called for instance `Softwares` in your `/home` directory with the `mkdir` command via `ssh`:
+
+    .. code-block:: console
+
+        $ ssh user@stockage.server.ch \
+        "mkdir -p /home/user/Softwares"
+
+    .. important::
+        The command `mkdir -p /home/user/Softwares` MUST be put inside ``""`` in order to pass and execute this command via `ssh`.
+
+3. Copy the downloaded archive to the created folder on the remote server. This can be achieved with the `scp` command:
+
+    .. code-block:: console
+
+        $ scp /local/path/to/git-annex-standalone-amd64.tar.gz \
+        user@stockage.server.ch:/home/user/Softwares/git-annex-standalone-amd64.tar.gz
+
+4. Extract the content of the archive to a folder `git-annex-standalone` with the `tar` command and remove it via `ssh`:
+
+    .. code-block:: console
+
+        $ ssh user@stockage.server.ch \
+        "tar xzvf /home/user/Softwares/git-annex-standalone-amd64.tar.gz -C git-annex-standalone && rm /home/user/Softwares/git-annex-standalone-amd64.tar.gz"
+
+    .. important::
+        The command `tar [...] && rm [...]` MUST be put inside ``""`` in order to pass and execute this sequence of commands via `ssh`.
+
+5. Connect to the remote data server via `ssh`:
+
+    .. code-block:: console
+
+        $ ssh user@stockage.server.ch
+
+    Then, open the ``~/.bashrc`` file with `vim` text editor for instance (`$ vim ~/.bashrc`) and add the following lines to update system `PATH` and `LD_LIBRARY_PATH`:
+
+    .. code-block:: console
+
+        export LD_LIBRARY_PATH="/home/user/Softwares/git-annex-standalone/bin:$LD_LIBRARY_PATH"
+        export PATH="/home/user/Softwares/git-annex-standalone:$PATH"
+
+    This finalizes the installation of the standalone `git-annex` binaries and libraries.
+
+    .. tip::
+        In `vim`, the key `i` goes into edition mode. When you are done, press the key `esc` and then `:wq` to tell vim to save your change (`w`) and quit (`q`).
+
+.. note::
+    In this approach, only git-annex is installed on the remote server and so, it would not be possible to directly manage Datalad datasets with Datalad directly there. If one wants to do so, this would require the installation of the dataset on a host machine where an installation of Datalad is available.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -10,6 +10,7 @@ Commandline Usage
     Before using `NeuroDataPub`, your dataset should be validated with the free, online `BIDS Validator <http://bids-standard.github.io/bids-validator/>`_,
     or its standalone version.
 
+    Note also that before using `NeuroDataPub`, the remote data server should provide at least an installation of `git-annex`. Please see :ref:`remote_setup` for instructions.
 
 .. _cliparser:
 

--- a/neurodatapub/info.py
+++ b/neurodatapub/info.py
@@ -1,9 +1,9 @@
 """Neurodatapub package information."""
 
 _version_major = 0
-_version_minor = 1
+_version_minor = 2
 
-__release_date__ = 'DD.MM.2021'
+__release_date__ = '09.08.2021'
 
 __version__ = "%s.%s" % (_version_major, _version_minor)
 

--- a/neurodatapub/project.py
+++ b/neurodatapub/project.py
@@ -17,6 +17,7 @@ from neurodatapub.utils.datalad import (
 )
 from neurodatapub.utils.gitannex import init_ssh_special_sibling, enable_ssh_special_sibling
 from neurodatapub.utils.io import copy_content_to_datalad_dataset
+from neurodatapub.utils.sshconfig import update_ssh_config
 
 
 class NeuroDataPubProject(HasTraits):
@@ -216,6 +217,13 @@ class NeuroDataPubProject(HasTraits):
 
     def configure_siblings(self):
         """Configure the siblings of the Datalad dataset for publication."""
+        # Update SSH config file to use self.remote_ssh_login
+        # by default when connecting to self.remote_ssh_url
+        print('> Update SSH config with special remote entry')
+        update_ssh_config(
+            sshurl=self.remote_ssh_url,
+            user=self.remote_ssh_login
+        )
         # Configuration of git-annex special remote sibling to host annexed files
         git_annex_special_sibling_config_dict = dict(
             {

--- a/neurodatapub/utils/datalad.py
+++ b/neurodatapub/utils/datalad.py
@@ -139,9 +139,8 @@ def publish_dataset(
     `res` : string
         Output of `datalad.api.publish()
     """
-    res = datalad.api.publish(
+    res = datalad.api.push(
         dataset=datalad_dataset_dir,
-        to='github',
-        jobs='auto'
+        to='github'
     )
     return res

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ from setuptools.command.install import install
 
 from neurodatapub.info import __version__
 
-directory = os.path.dirname(os.path.abspath(__file__))
+directory = os.path.abspath(os.path.dirname(__file__))
+
+# Read the contents of your README file
+with open(os.path.join(directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
@@ -83,10 +87,7 @@ def main():
             description=
             'NeuroDataPub: Tool built for publication of BIDS datasets '
             'of the NCCR-Synapsy',
-            long_description=
-            """NeuroDataPub is built on top of Datalad and helps
-            NCCR-Synapsy members in the task of referencing its dataset
-            to the NCCR-SYNAPSY GitHub organization. """,
+            long_description=long_description,
             author='Sebastien Tourbier',
             author_email='sebastien.tourbier@alumni.epfl.ch',
             url='https://github.com/NCCR-SYNAPSY/neurodatapub',


### PR DESCRIPTION
## List of changes

### New Features

*  Update automatically the SSH config with an entry for the remote SSH server to configure the user login used by default by ssh. ([PR\#25](https://github.com/NCCR-SYNAPSY/neurodatapub/pull/25))

### Documentation

*   Add documentation page to give instructions for the remote data server setup. ([PR\#28](https://github.com/NCCR-SYNAPSY/neurodatapub/pull/28))
*   Update documentation for the creation of the conda environment and the installation of git-annex on Linux and MacOSX ([PR#23](https://github.com/NCCR-SYNAPSY/neurodatapub/pull/23))

### Bug Fixes

*  Replace *old* `datalad.api.publish()` with *new* `datalad.api.push()`. ([PR\#22](https://github.com/NCCR-SYNAPSY/neurodatapub/pull/22))

### Misc

*   Add conda/environment\_macosx.yml, a conda environment file specific to MacOSX where git-annex is not included. ([PR\#23](https://github.com/NCCR-SYNAPSY/neurodatapub/pull/23))
*   Use content of README as `long_description` in `setup.py` for publication to PyPI. ([PR\#26](https://github.com/NCCR-SYNAPSY/neurodatapub/pull/26))